### PR TITLE
Fix category assignment and display in expenses

### DIFF
--- a/E-Agenda.WebApp/Models/DespesaViewModels.cs
+++ b/E-Agenda.WebApp/Models/DespesaViewModels.cs
@@ -72,7 +72,8 @@ public class EditarDespesaViewModel : FormularioDespesaViewModel
         CategoriasDisponiveis = new();
     }
 
-    public EditarDespesaViewModel(Guid id, string descricao, DateOnly dataOcorrencia, decimal valor, TipoPagamento formaPagamento, List<Categoria> categorias) : this()
+    public EditarDespesaViewModel(Guid id, string descricao, DateOnly dataOcorrencia, decimal valor,
+        TipoPagamento formaPagamento, List<Categoria> categoriasDisponiveis, List<Categoria> categoriasSelecionadas) : this()
     {
         Id = id;
         Descricao = descricao;
@@ -80,11 +81,13 @@ public class EditarDespesaViewModel : FormularioDespesaViewModel
         Valor = valor;
         FormaPagamento = formaPagamento;
 
-        foreach (var c in categorias)
+        foreach (var c in categoriasDisponiveis)
         {
             var categoriaDisponivel = new SelectListItem(c.Titulo, c.Id.ToString());
             CategoriasDisponiveis.Add(categoriaDisponivel);
         }
+
+        CategoriasSelecionadas = categoriasSelecionadas.Select(c => c.Id).ToList();
     }
 }
 


### PR DESCRIPTION
## Summary
- correctly parse selected categories in DespesaController
- persist category linkage when creating or editing despesas
- include all categories in edit form and mark selected ones
- keep categories updated when deleting an expense

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685975ff6d9c83269fdc10f41aa41c46